### PR TITLE
Turn Synchronization and Cache–Database Inconsistency fix

### DIFF
--- a/Dystopia.Tests/Database/GameRepositoryTests.cs
+++ b/Dystopia.Tests/Database/GameRepositoryTests.cs
@@ -162,11 +162,9 @@ public class GameRepositoryTests
             .Setup(c => c.TryGetAll(
                 It.IsAny<Func<GameViewModel, bool>>(),
                 out It.Ref<IList<GameViewModel>>.IsAny))
-            .Returns((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
+            .Callback((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
             {
                 values = new List<GameViewModel>();
-
-                return true;
             });
 
         // Act
@@ -201,14 +199,12 @@ public class GameRepositoryTests
             .Setup(c => c.TryGetAll(
                 It.IsAny<Func<GameViewModel, bool>>(),
                 out It.Ref<IList<GameViewModel>>.IsAny))
-            .Returns((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
+            .Callback((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
             {
                 values = new List<GameViewModel>();
                 values.Add(new() { Id = Guid.NewGuid(), CurrentGameStateData = new byte[] { 4 } });
                 values.Add(new() { Id = Guid.NewGuid(), CurrentGameStateData = new byte[] { 5 } });
                 values.Add(new() { Id = Guid.NewGuid(), CurrentGameStateData = new byte[] { 6 } });
-
-                return true;
             });
 
         // Act
@@ -243,14 +239,12 @@ public class GameRepositoryTests
             .Setup(c => c.TryGetAll(
                 It.IsAny<Func<GameViewModel, bool>>(),
                 out It.Ref<IList<GameViewModel>>.IsAny))
-            .Returns((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
+            .Callback((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
             {
                 values = new List<GameViewModel>();
                 values.Add(new() { Id = Guid.NewGuid(), CurrentGameStateData = new byte[] { 4 } });
                 values.Add(new() { Id = Guid.NewGuid(), CurrentGameStateData = new byte[] { 5 } });
                 values.Add(new() { Id = Guid.NewGuid(), CurrentGameStateData = new byte[] { 6 } });
-
-                return true;
             });
 
         // Act
@@ -293,7 +287,7 @@ public class GameRepositoryTests
             .Setup(c => c.TryGetAll(
                 It.IsAny<Func<GameViewModel, bool>>(),
                 out It.Ref<IList<GameViewModel>>.IsAny))
-            .Returns((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
+            .Callback((Func<GameViewModel, bool> predicate, out IList<GameViewModel> values) =>
             {
                 values = new List<GameViewModel>();
                 values.Add(new() { Id = Guid.NewGuid(), CurrentGameStateData = new byte[] { 6 } });
@@ -302,8 +296,6 @@ public class GameRepositoryTests
 
                 values.Add(new() { Id = overlapGuidA, CurrentGameStateData = new byte[] { 4 } });
                 values.Add(new() { Id = overlapGuidB, CurrentGameStateData = new byte[] { 5 } });
-
-                return true;
             });
 
         // Act

--- a/Dystopia/Database/Game/PolydystopiaGameRepository.cs
+++ b/Dystopia/Database/Game/PolydystopiaGameRepository.cs
@@ -82,7 +82,7 @@ public class PolydystopiaGameRepository : IPolydystopiaGameRepository
 
     public async Task<List<GameViewModel>> GetAllGamesByPlayer(Guid playerId)
     {
-        var _ = _cacheService.TryGetAll(
+        _cacheService.TryGetAll(
             model => _bridge.IsPlayerInGame(playerId.ToString(), model.CurrentGameStateData),
             out var cachedPlayerGames);
 

--- a/Dystopia/Database/Game/PolydystopiaGameRepository.cs
+++ b/Dystopia/Database/Game/PolydystopiaGameRepository.cs
@@ -35,6 +35,7 @@ public class PolydystopiaGameRepository : IPolydystopiaGameRepository
         {
             return model;
         }
+
         model = await _dbContext.Games.FindAsync(id) ?? null;
 
         return model;
@@ -72,6 +73,7 @@ public class PolydystopiaGameRepository : IPolydystopiaGameRepository
             // await _dbContext.SaveChangesAsync();
             // Add this if it is catastrophic when live games or last few moves of games are deleted on server crash.
         }
+
         _dbContext.Games.Update(gameViewModel);
         await _dbContext.SaveChangesAsync();
 
@@ -80,9 +82,16 @@ public class PolydystopiaGameRepository : IPolydystopiaGameRepository
 
     public async Task<List<GameViewModel>> GetAllGamesByPlayer(Guid playerId)
     {
-        // no need to cache as it is usually not relevant. TODO fix when custom entities are implemented(just have a list of playerid in game)
-        var allGames = await _dbContext.Games.ToListAsync();
-        return allGames
-            .Where(game => _bridge.IsPlayerInGame(playerId.ToString(), game.CurrentGameStateData)).ToList();
+        var _ = _cacheService.TryGetAll(
+            model => _bridge.IsPlayerInGame(playerId.ToString(), model.CurrentGameStateData),
+            out var cachedPlayerGames);
+
+        var allDbGames = await _dbContext.Games.ToListAsync();
+        var dbPlayerGames =
+            allDbGames.Where(game =>
+                _bridge.IsPlayerInGame(playerId.ToString(), game.CurrentGameStateData) &&
+                cachedPlayerGames.All(c => c.Id != game.Id));
+
+        return cachedPlayerGames.Concat(dbPlayerGames).ToList();
     }
 }

--- a/Dystopia/Services/Cache/CacheService.cs
+++ b/Dystopia/Services/Cache/CacheService.cs
@@ -30,6 +30,28 @@ public class CacheService<T> : ICacheService<T>
         return false;
     }
 
+    public bool TryGetAll(Func<T, bool> predicate, out IList<T> values)
+    {
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        var matches = new List<T>();
+
+        foreach (var kvp in _cache)
+        {
+            var (value, _, _) = kvp.Value;
+            if (predicate(value))
+            {
+                matches.Add(value);
+            }
+        }
+
+        values = matches;
+        return true;
+    }
+
     public void Set(Guid key, T value, Action<PolydystopiaDbContext> saveToDisk)
     {
         _cache[key] = (value, DateTime.Now, saveToDisk);

--- a/Dystopia/Services/Cache/CacheService.cs
+++ b/Dystopia/Services/Cache/CacheService.cs
@@ -30,26 +30,22 @@ public class CacheService<T> : ICacheService<T>
         return false;
     }
 
-    public bool TryGetAll(Func<T, bool> predicate, out IList<T> values)
+    public void TryGetAll(Func<T, bool> predicate, out IList<T> values)
     {
         if (predicate == null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
 
-        var matches = new List<T>();
+        values = new List<T>();
 
-        foreach (var kvp in _cache)
+        foreach (var (_, (value, _, _)) in _cache)
         {
-            var (value, _, _) = kvp.Value;
             if (predicate(value))
             {
-                matches.Add(value);
+                values.Add(value);
             }
         }
-
-        values = matches;
-        return true;
     }
 
     public void Set(Guid key, T value, Action<PolydystopiaDbContext> saveToDisk)

--- a/Dystopia/Services/Cache/ICacheService.cs
+++ b/Dystopia/Services/Cache/ICacheService.cs
@@ -5,7 +5,8 @@ namespace Dystopia.Services.Cache
 {
     public interface ICacheService<T>
     {
-        bool TryGet(Guid ke, out T? value);
+        bool TryGet(Guid key, out T? value);
+        bool TryGetAll(Func<T, bool> predicate, out IList<T> values);
         void Set(Guid key, T value, Action<PolydystopiaDbContext> saveToDisk);
         void TryRemove(Guid key);
         void CleanStaleCache(TimeSpan staleTime, PolydystopiaDbContext dbContext);

--- a/Dystopia/Services/Cache/ICacheService.cs
+++ b/Dystopia/Services/Cache/ICacheService.cs
@@ -6,7 +6,7 @@ namespace Dystopia.Services.Cache
     public interface ICacheService<T>
     {
         bool TryGet(Guid key, out T? value);
-        bool TryGetAll(Func<T, bool> predicate, out IList<T> values);
+        void TryGetAll(Func<T, bool> predicate, out IList<T> values);
         void Set(Guid key, T value, Action<PolydystopiaDbContext> saveToDisk);
         void TryRemove(Guid key);
         void CleanStaleCache(TimeSpan staleTime, PolydystopiaDbContext dbContext);


### PR DESCRIPTION
Closes #27 

We really need to save player information outside of games in the future. Right now we need to iterate over every game in the database to get the games of a player.